### PR TITLE
playerPed reference doesn't exist after SetPlayerModel

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -102,7 +102,7 @@ function LoadDefaultModel(malePed, cb)
 
 		if IsModelInCdimage(characterModel) and IsModelValid(characterModel) then
 			SetPlayerModel(PlayerId(), characterModel)
-			SetPedDefaultComponentVariation(playerPed)
+			SetPedDefaultComponentVariation(PlayerPedId())
 		end
 
 		SetModelAsNoLongerNeeded(characterModel)


### PR DESCRIPTION
SetPlayerModel(
	player --[[ Player ]], 
	model --[[ Hash ]]
)
Set the model for a specific Player. Be aware that this will destroy the current Ped for the Player and create a new one, any reference to the old ped should be reset (by using the GetPlayerPed native).